### PR TITLE
Include untracked files when stashing before repo update

### DIFF
--- a/packages/update-epic-workshop/bin.js
+++ b/packages/update-epic-workshop/bin.js
@@ -28,7 +28,7 @@ export async function updateLocalRepo() {
 
 		if (uncommittedChanges) {
 			console.log('👜 Stashing uncommitted changes...')
-			await execaCommand('git stash', { cwd })
+			await execaCommand('git stash --include-untracked', { cwd })
 		}
 
 		console.log('⬇️ Pulling latest changes...')


### PR DESCRIPTION
Otherwise, following `git stash pop` command would fail.

The change is to use `--include-untracked` flag in the stash command.

Fixes https://github.com/epicweb-dev/epicshop/issues/224